### PR TITLE
Solve the crash after adding comments

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -22,7 +22,7 @@ var (
 	regexpHexNumber                  = regexp.MustCompile(`0x[0-9a-f]+`)
 	regexpFuncLine                   = regexp.MustCompile(`^func[\s][a-zA-Z0-9]+[(](.*)[)][\s]*{`)
 	regexpParseDebugLineFindFunc     = regexp.MustCompile(`[\.]Debug[\(](.*)[/)]`)
-	regexpParseDebugLineParseVarName = regexp.MustCompile(`[\.]Debug[\(](.*)[/)]`)
+	regexpParseDebugLineParseVarName = regexp.MustCompile(`[\.]Debug[\(](.*)\)`)
 	regexpFindVarDefinition          = func(varName string) *regexp.Regexp {
 		return regexp.MustCompile(fmt.Sprintf(`%s[\s\:]*={1}([\s]*[a-zA-Z0-9\._]+)`, varName))
 	}


### PR DESCRIPTION
When I write comments after code,it will panic.I found that this error occurs because of regular expressions.This error can be resolved when I write like this.